### PR TITLE
Modernize integration tests with pytest-docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
-# Example environment configuration for docker-compose
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=mypassword
-POSTGRES_DB=noco_base
-NC_AUTH_JWT_SECRET=your-default-secret
-POSTGRES_DATA_PATH=./data/postgres_db
-NOCO_DATA_PATH=./data/noco_db
+# Local development defaults
+NOCO_URL=http://localhost:8080
+NC_AUTH_JWT_SECRET=your-secret
+NC_USER=admin@example.com
+NC_PASS=password
+NC_PROJECT_ID=1

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ pytest -q
 
 integration:
 docker-compose up -d
-NOCO_TEST_ONLINE=1 pytest -q
+pytest -q
 docker-compose down

--- a/README.md
+++ b/README.md
@@ -3,21 +3,13 @@ Client written in Python to interact with the nocodb api
 
 ## Testing
 
-A `docker-compose.yml` file is provided for spinning up a local NocoDB and PostgreSQL instance. Copy `.env.example` to `.env` and adjust any values if needed. Start the services and run the integration tests using the following commands:
+A `docker-compose.yml` file is provided for spinning up a local NocoDB and PostgreSQL instance. Copy `.env.example` to `.env` and adjust any values if needed. Tests use `pytest-docker` to automatically start and stop the services.
 
-
-```bash
-docker-compose up -d
-NOCO_TEST_ONLINE=1 pytest
-```
-
-To stop the services run:
+Run the tests with:
 
 ```bash
-docker-compose down
+pytest -q
 ```
-
-Running `pytest` without the `NOCO_TEST_ONLINE` variable will skip the integration tests.
 
 ## License
 This project is licensed under the GNU Affero General Public License v3.0 - see the [LICENSE](LICENSE) file for details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3.8"
 services:
   postgres:
     image: postgres:14
@@ -24,8 +25,8 @@ services:
     container_name: nocodb_cont
     restart: always
     environment:
-      NC_DB: "pg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-mypassword}@postgres:5432?u=${POSTGRES_USER:-postgres}&p=${POSTGRES_PASSWORD:-mypassword}&d=${POSTGRES_DB:-noco_base}"
-      NC_AUTH_JWT_SECRET: ${NC_AUTH_JWT_SECRET:-your-default-secret}
+      NC_DB: "pg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432?u=${POSTGRES_USER}&p=${POSTGRES_PASSWORD}&d=${POSTGRES_DB}"
+      NC_AUTH_JWT_SECRET: ${NC_AUTH_JWT_SECRET}
     volumes:
       - nocodb_data:/usr/app/data/
     ports:
@@ -38,19 +39,9 @@ services:
 
 volumes:
   postgres_data:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: ${POSTGRES_DATA_PATH:-./data/postgres_db}
   nocodb_data:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: ${NOCO_DATA_PATH-./data/noco_db}
 
 networks:
   network:
     driver: bridge
-x-compatibility: true
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+docker_compose_file = docker-compose.yml
+docker_services_timeout = 30.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-docker
+python-dotenv
+requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+import os
+import pytest
+import requests
+from src import NocoDBClient
+
+
+@pytest.fixture(scope="session")
+def api_token(docker_ip, docker_services):
+    port = docker_services.wait_for_service("nocodb", 8080)
+    base = f"http://{docker_ip}:{port}"
+
+    r = requests.post(
+        f"{base}/api/v1/auth/signin",
+        json={"email": os.getenv("NC_USER", "admin@example.com"),
+              "password": os.getenv("NC_PASS", "password")}
+    )
+    r.raise_for_status()
+    jwt = r.json()["jwt"]
+
+    headers = {"xc-auth": jwt}
+    r = requests.get(
+        f"{base}/api/v1/db/meta/projects/{os.getenv('NC_PROJECT_ID', '1')}/api-tokens",
+        headers=headers
+    )
+    r.raise_for_status()
+    tokens = r.json()
+    if tokens:
+        return tokens[0]["token"]
+
+    r = requests.post(
+        f"{base}/api/v1/db/meta/projects/{os.getenv('NC_PROJECT_ID', '1')}/api-tokens",
+        headers=headers
+    )
+    r.raise_for_status()
+    return r.json()["token"]
+
+
+@pytest.fixture(scope="session")
+def client(docker_ip, docker_services, api_token):
+    port = docker_services.port_for("nocodb", 8080)
+    base = f"http://{docker_ip}:{port}"
+    os.environ["NOCODB_BASE_URL"] = f"{base}/api/v1"
+    os.environ["NOCODB_API_KEY"] = api_token
+    return NocoDBClient()
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,18 +1,3 @@
-import os
-import importlib.util
-import pytest
-
-if importlib.util.find_spec("requests") is None:
-    pytest.skip("requests package not installed", allow_module_level=True)
-
-from src import NocoDBClient
-
-@pytest.fixture(scope="module")
-def client():
-    return NocoDBClient()
-
-
 def test_validate_connection(client):
-    if not os.environ.get("NOCO_TEST_ONLINE"):
-        pytest.skip("NOCO_TEST_ONLINE not set; skipping integration test")
     assert client.validate_connection()
+


### PR DESCRIPTION
## Summary
- drop placeholder client module and revert fixtures to use the original `NocoDBClient`
- make docker-compose volumes ephemeral rather than bind mounted
- update `.env.example` and `.gitignore`
- adjust integration test fixture to configure environment variables on the fly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6867a36b5494832bb49fc5b19bb1ec0e