### PR TITLE
Add configurable initialization

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+
+from nococlient import NocoDBClient, NocoDBConfig
+
+
+def test_init_with_explicit_params(monkeypatch):
+    monkeypatch.delenv("NOCODB_BASE_URL", raising=False)
+    monkeypatch.delenv("NOCODB_API_KEY", raising=False)
+    client = NocoDBClient(base_url="http://example.com", api_key="abc")
+    assert client.config.base_url == "http://example.com"
+    assert client.config.api_key == "abc"
+
+
+def test_init_with_config(monkeypatch):
+    monkeypatch.delenv("NOCODB_BASE_URL", raising=False)
+    monkeypatch.delenv("NOCODB_API_KEY", raising=False)
+    cfg = NocoDBConfig(base_url="http://cfg", api_key="key")
+    client = NocoDBClient(config=cfg)
+    assert client.config.base_url == "http://cfg"
+    assert client.config.api_key == "key"
+
+
+def test_init_missing(monkeypatch):
+    monkeypatch.delenv("NOCODB_BASE_URL", raising=False)
+    monkeypatch.delenv("NOCODB_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        NocoDBClient()


### PR DESCRIPTION
## Summary
- add optional fields to `NocoDBConfig`
- allow providing config or explicit params in `NocoDBClient.__init__`
- load environment variables when values are missing and error if unavailable
- add tests for new initialization logic

## Testing
- `pytest tests/test_config.py -q`
- `pytest -q` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876572b8e9c832bb224d4a7ba50e23d